### PR TITLE
Missing rsca

### DIFF
--- a/src/js/data/providers/DataProvider.js
+++ b/src/js/data/providers/DataProvider.js
@@ -3,15 +3,15 @@ import * as d3 from 'd3';
 import { min } from 'd3';
 
 const { fields } = require('../schema');
-const { getPageElements }= require('../../page-components.js')
+const { getPageElements } = require('../../page-components.js');
 
 export class DataProvider {
     constructor(parsedData) {
         this.psr = this.format(parsedData);
-        this.startDate= this.getStartDate();
-        this.endDate= this.getEndDate();
+        this.startDate = this.getStartDate();
+        this.endDate = this.getEndDate();
         this.validatePsr();
-        
+
         this.setTimeScale();
 
         for (let k in fields) {
@@ -56,7 +56,6 @@ export class DataProvider {
     }
 
     setTimeScale() {
-
         this.min_start_date = this.startDate;
         this.max_end_date = this.endDate;
 
@@ -74,8 +73,10 @@ export class DataProvider {
 
     getStartDate() {
         const start_dates = this.psr.map((d) => d.start_date);
-        const {fp_start_date} = getPageElements();
-        let startDate=new Date(Math.max(Math.min(...start_dates), ...fp_start_date.selectedDates));
+        const { fp_start_date } = getPageElements();
+        let startDate = new Date(
+            Math.max(Math.min(...start_dates), ...fp_start_date.selectedDates)
+        );
         fp_start_date.setDate(startDate, false);
         return startDate;
     }

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -20,7 +20,6 @@ export const clear_psr_viz = (canvas) => {
 
     d3.select(canvas).select('#rep_sen_idt_g').selectAll('g').remove();
 
-
     d3.select(canvas).selectAll('g.fitrep').remove();
 
     d3.select(canvas).selectAll('g.x.axis').remove();
@@ -225,7 +224,7 @@ function make_atcc_reporting_senior_bars(data) {
     );
 }
 
-function draw_axises(group, data) {
+function draw_axes(group, data) {
     // Draw time axis
     group
         .append('g')
@@ -259,7 +258,7 @@ function draw_fitrep_graph(data, group) {
         .style('opacity', 0)
         .style('pointer-events', 'none');
 
-    draw_axises(group, data);
+    draw_axes(group, data);
 
     group.on('mouseenter', function () {
         clear_fitrep_highlight(fitrep_highlight);
@@ -275,7 +274,7 @@ function draw_fitrep_graph(data, group) {
         .attr('transform', function (d) {
             return `translate(${data.time_scale(
                 d.end_date
-            )}, ${lib.rsca_scale(d.trait_avg - d.rsca)})`;
+            )}, ${d.rsca ? lib.rsca_scale(d.trait_avg - d.rsca) : lib.rsca_scale(0)})`;
         });
 
     // Draw FITREP markers
@@ -311,8 +310,13 @@ function draw_fitrep_graph(data, group) {
             return symbol.size(size)();
         })
         .attr('fill', 'none')
-        .attr('stroke', (d) => lib.fitrep_color_scale(d.prom_rec.toUpperCase()))
-        .attr('stroke', (d) => 'black')
+        .attr('stroke', function (d) {
+            if (d.prom_rec.toUpperCase() != 'NOB' && d.rsca == 0) {
+                return 'red';
+            } else {
+                return 'black';
+            }
+        })
         .attr('stroke-width', lib.fitrep_marker_stroke_width)
         .attr('opacity', 1)
         .on('mouseover', function (event, d) {
@@ -331,7 +335,7 @@ function draw_fitrep_graph(data, group) {
     const line = d3
         .line()
         .x((d) => data.time_scale(d.end_date))
-        .y((d) => lib.rsca_scale(d.trait_avg - d.rsca));
+        .y((d) => lib.rsca_scale(d.rsca ? d.trait_avg - d.rsca : 0));
 
     group
         .selectAll('lines')
@@ -404,6 +408,7 @@ function fitrep_tooltip(d) {
     var delta = d.trait_avg ? (d.trait_avg - d.rsca).toFixed(2) : 'n/a';
     delta = delta == '-0.00' ? '0.00' : delta;
     delta = delta > 0 ? '+' + delta : delta;
+    delta = d.rsca ? delta : 'n/a';
 
     var return_val = `
     <strong>Period:</strong> ${lib.date_formatter(

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -30,7 +30,15 @@ export const idt_command_bar_color = '#088199';
 export const at_cc_command_bar_color = '#e8b00f';
 
 // FITREP marker styling
-export const prom_rec_categories = ['EP', 'MP', 'P', 'PR', 'SP', 'NOB'];
+export const prom_rec_categories = [
+    'EP',
+    'MP',
+    'P',
+    'PR',
+    'SP',
+    'NOB',
+    'Missing RSCA',
+];
 export const fitrep_traffic_legend_sizes = [1, 3, 5, 10, 15];
 
 export const ep_color = '#48ff00';
@@ -39,6 +47,7 @@ export const p_color = 'black';
 export const pr_color = 'yellow';
 export const sp_color = 'red';
 export const nob_color = 'lightgrey';
+export const missing_rsca_color = 'none';
 export const fitrep_traffic_legend_marker_color = 'none';
 
 export const ep_shape = d3.symbol().type(d3.symbolCircle);
@@ -55,13 +64,34 @@ export const fitrep_marker_stroke_width = 1.5;
 
 export const fitrep_color_scale = d3
     .scaleOrdinal()
-    .domain(['EP', 'MP', 'P', 'PR', 'SP', 'NOB'])
-    .range([ep_color, mp_color, p_color, pr_color, sp_color, nob_color]);
+    .domain(['EP', 'MP', 'P', 'PR', 'SP', 'NOB', 'MISSING RSCA'])
+    .range([
+        ep_color,
+        mp_color,
+        p_color,
+        pr_color,
+        sp_color,
+        nob_color,
+        missing_rsca_color,
+    ]);
+
+export const fitrep_stroke_scale = d3
+    .scaleOrdinal()
+    .domain(['EP', 'MP', 'P', 'PR', 'SP', 'NOB', 'MISSING RSCA'])
+    .range(['black', 'black', 'black', 'black', 'black', 'black', 'red']);
 
 export const fitrep_shape_scale = d3
     .scaleOrdinal()
-    .domain(['EP', 'MP', 'P', 'PR', 'SP', 'NOB'])
-    .range([ep_shape, mp_shape, p_shape, pr_shape, sp_shape, nob_shape]);
+    .domain(['EP', 'MP', 'P', 'PR', 'SP', 'NOB', 'Missing RSCA'])
+    .range([
+        ep_shape,
+        mp_shape,
+        p_shape,
+        pr_shape,
+        sp_shape,
+        nob_shape,
+        nob_shape,
+    ]);
 
 export const fitrep_marker_size = d3
     .scaleLinear()

--- a/src/js/page-components.js
+++ b/src/js/page-components.js
@@ -1,6 +1,6 @@
 import * as lib from './lib.js';
 import * as d3 from 'd3';
-import flatpickr from "flatpickr";
+import flatpickr from 'flatpickr';
 
 let svg,
     container_g,
@@ -29,7 +29,7 @@ export const getPageElements = () => ({
     fitreps_g,
     legend_canvas,
     rerender_button,
-    fp_start_date    
+    fp_start_date,
 });
 
 export const buildElements = (grid) => {
@@ -65,11 +65,10 @@ export const buildElements = (grid) => {
         .text('Re-Render')
         .style('display', 'none');
 
-    fp_start_date=
-        flatpickr("#start-date", {
-            position: "above left",
-            dateFormat: "m/d/Y"
-        });
+    fp_start_date = flatpickr('#start-date', {
+        position: 'above left',
+        dateFormat: 'm/d/Y',
+    });
 
     return getPageElements();
 };
@@ -207,7 +206,7 @@ export function draw_legend() {
                     )
                 })`
         );
-    /// Outlines
+    /// Marker fill
     prom_rec_legend_marker_groups
         .append('path')
         .attr('d', function (d) {
@@ -226,7 +225,7 @@ export function draw_legend() {
             return symbol.size(size)();
         })
         .attr('fill', 'none')
-        .attr('stroke', 'black')
+        .attr('stroke', (d) => lib.fitrep_stroke_scale(d.toUpperCase()))
         .attr('stroke-width', lib.fitrep_marker_stroke_width);
     /// Labels
     prom_rec_legend_marker_groups
@@ -240,7 +239,7 @@ export function draw_legend() {
                         lib.fitrep_marker_size(lib.fitrep_legend_marker_size)) /
                         Math.PI
                 )
-            })`
+            },5)`
         )
         .text((d) => d);
 
@@ -299,7 +298,7 @@ export function draw_legend() {
                         lib.fitrep_marker_size(lib.fitrep_legend_marker_size)) /
                         Math.PI
                 )
-            })`
+            },5)`
         )
         .text((d) => d);
 
@@ -366,13 +365,14 @@ export function draw_legend() {
         .style('dominant-baseline', 'middle');
 }
 
-export function addHTMLTemplates(){
-    let templates=[
-        'faqs'
-    ];
+export function addHTMLTemplates() {
+    let templates = ['faqs'];
 
-    templates.map(filename=>d3.select('body')
-        .append('div')
-        .attr('id', filename)
-        .html(require(`../templates/${filename}.html`).default))
+    templates.map((filename) =>
+        d3
+            .select('body')
+            .append('div')
+            .attr('id', filename)
+            .html(require(`../templates/${filename}.html`).default)
+    );
 }


### PR DESCRIPTION
I demo'ed the website to the CO. When he ran his PSR through it, it had a FITREP whose marker sent off the page. Turned out the RSCA for that FITREP hadn't populated yet, and the viz wasn't made to handle that. This update handles it.

* Missing-RSCA FITREPs get put on the x-axis of the chart
* Non-NOB, missing-RSCA FITREPs get a red stroke
* Added 'Missing RSCA' to the legend 